### PR TITLE
prevent a Windows Firewall dialog window

### DIFF
--- a/lib/freeport.js
+++ b/lib/freeport.js
@@ -10,5 +10,5 @@ module.exports = function(cb) {
   server.on('close', function() {
     cb(null, port)
   })
-  server.listen(0)
+  server.listen(0, '127.0.0.1')
 }


### PR DESCRIPTION
When you omit the `host` (the second parameter of `server.listen`), the server will accept connections directed to any IPv4 address (`INADDR_ANY`). This will cause Windows Firewall (in its default mode, which is relatively safe) to block Node.js from accepting incoming connections through the firewall and to display a dialog window where the user may unblock Node.js manually.

Here's an example of such window from the Russian version of Windows 7:

![(screenshot)](https://cloud.githubusercontent.com/assets/1088720/3563974/0f04eb7a-0a64-11e4-8df6-607f63c3699b.png)

I'd like to propose a patch that causes the freeport module to listen to `127.0.0.1` (the localhost) only, and thus the firewall is not triggered on Windows. An application may trigger it later when it really becomes necessary to accept some connections from the Internet. Sometimes it won't. I mean, in some applications (such as a local express-based server from within a node-webkit-based application, see rogerwang/node-webkit#2066) a local connection is quite enough and it won't be necessary to traverse the firewall ever.

The check for a free port remains almost as good as before the proposed changes (if some port is busy in `INADDR_ANY` mode, you won't be able to listen to that port even on the localhost).
