### PR TITLE
Remove engine field

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,5 @@
   "scripts": { "test": "NODE_PATH=./lib mocha --ui exports" },
   "devDependencies": {
     "mocha": "0.12.x"
-  },
-  "engines": { "node": "0.6.x" }
+  }
 }


### PR DESCRIPTION
I don't think that it's necessary since freeport is using a stable api of node.js. And currently it prints a warning into the console when installing it on node 0.10.x.
