### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/daaku/nodejs-freeport"
   },
   "scripts": { "test": "NODE_PATH=./lib mocha --ui exports" },
+  "license": "Apache-2.0"
   "devDependencies": {
     "mocha": "0.12.x"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
